### PR TITLE
Adding in py_modules to the keypatch setup.py example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ from setuptools import setup, find_packages
 setup(name='keypatch',
       version="0.0",
       packages=find_packages(exclude=['ez_setup']),
+      py_modules=['keypatch'],
       install_requires=[
           "keystone-engine"
       ],


### PR DESCRIPTION
Since keypatch is setup as a single file as opposed to a package, you have to add the py_modules paramater to have it installed properly. The setup.py can now be copy/pasta'd into keypatch directory and should install properly.